### PR TITLE
Add 'work/' to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules/
+work/


### PR DESCRIPTION
workディレクトリ下の資材がdiffに出てきまくるのが邪魔すぎるので。