### PR TITLE
Add shared-devcon-react submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-devcon-react"]
+	path = shared-devcon-react
+	url = https://github.com/weworku/shared-devcon-react.git


### PR DESCRIPTION
react用devconteinerを切り出したリポジトリ「shared-devcon-react」をサブモジュールとして追加しました

自動更新等をgithookなどでやりたいが今のところ未実施

コンテナの内容は変わらないので、workフォルダにあるプロジェクトは、同じくworkフォルダに移せばそのまま利用可能