### PR TITLE
🔧 React 開発用テンプレートの Node.js バージョンを 22.x に更新

### DIFF
--- a/react/Dockerfile
+++ b/react/Dockerfile
@@ -1,10 +1,9 @@
 #FROM node:21-alpine3.18
-FROM node:21-slim
+FROM node:22-slim
 RUN set -x \
   && apt update \
   && apt upgrade -y \
-  && apt install -y git
+  && apt install -y git vim less curl jq
 ENV LESSCHARSET=utf-8
 WORKDIR /usr/src/app
 COPY ./profile.d/alias.sh /etc/profile.d
-


### PR DESCRIPTION
Fixes #25 

## 概要
react ディレクトリ配下の Dev Container 環境にて使用されている Node.js のバージョンを、現在の 21.x から最新の LTS または安定版である 22.x 系にアップデートしました。

Node.js 22.x 系は現在アクティブな開発・テスト環境において採用が進んでおり、依存パッケージやツールチェインとの互換性維持のためにも、追従が望まれます。

## 対象ファイル
- `Dockerfile`

## 作業内容
- Dockerfile のベースイメージを`node:22-slim`に変更
- ついでにツールも追加 (vim less curl jq)
- React テンプレートプロジェクトが問題なく動作することを確認
