### PR TITLE
Add Dev Containers config for Rails8 development with DooD

### DIFF
--- a/rails-8-dood/.devcontainer/devcontainer.json
+++ b/rails-8-dood/.devcontainer/devcontainer.json
@@ -5,6 +5,9 @@
     ],
     "service": "dev",
     "workspaceFolder": "/usr/src/app",
+    "mounts": [
+        "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+    ],
     "customizations": {
         "vscode": {
             "extensions": [

--- a/rails-8-dood/.devcontainer/devcontainer.json
+++ b/rails-8-dood/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+{
+    "name": "rails-8-dood",
+    "dockerComposeFile": [
+        "../compose.yml"
+    ],
+    "service": "dev",
+    "workspaceFolder": "/usr/src/app",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "Github.vscode-pull-request-github",
+                "rebornix.Ruby",
+                "Shopify.ruby-lsp",
+                "castwide.solargraph",
+                "bung87.rails",
+                "aliariff.vscode-erb-beautify",
+                "kaiwood.endwise",
+                "connorshea.vscode-ruby-test-adapter"
+            ],
+            "settings": {
+                "editor.formatOnSave": true,
+                "[ruby]": {
+                    "editor.defaultFormatter": "Shopify.ruby-lsp",
+                    "editor.formatOnSave": true
+                },
+                "[erb]": {
+                    "editor.defaultFormatter": "aliariff.vscode-erb-beautify",
+                    "editor.tabSize": 2
+                },
+                "rubyLsp.rubyVersionManager": "rbenv",
+                "rubyLsp.enableExperimentalFeatures": true,
+                "rubyLsp.diagnostics.enable": true,
+                "rubyLsp.formatter": "rubocop",
+                "ruby.testExplorer.useBundler": true,
+                "rails.schemaRefreshPattern": "db/schema.rb"
+            }
+        }
+    }
+}

--- a/rails-8-dood/Dockerfile
+++ b/rails-8-dood/Dockerfile
@@ -11,6 +11,14 @@ RUN set -x \
     git \
     vim \
     jq \
+    ca-certificates \
+    gnupg \
+  && install -m 0755 -d /etc/apt/keyrings \
+  && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+  && chmod a+r /etc/apt/keyrings/docker.gpg \
+  && echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
+  && apt-get update \
+  && apt-get install -y docker-ce-cli docker-compose-plugin \
   && rm -rf /var/lib/apt/lists/* \
   && gem install rails -v 8 \
   && gem install pg \

--- a/rails-8-dood/Dockerfile
+++ b/rails-8-dood/Dockerfile
@@ -11,6 +11,7 @@ RUN set -x \
     git \
     vim \
     jq \
+    htop \
     ca-certificates \
     gnupg \
   && install -m 0755 -d /etc/apt/keyrings \
@@ -27,6 +28,10 @@ RUN set -x \
 RUN set -x \
   && groupadd -g 998 docker \
   && useradd -m -s /bin/bash -G docker -u 1000 rails
+ENV BUNDLE_PATH=/home/rails/.bundle
+ENV BUNDLE_APP_CONFIG=/home/rails/.bundle
+ENV BUNDLE_BIN=/home/rails/.bundle/bin
+ENV PATH=$BUNDLE_BIN:$PATH
 
 COPY ./profile.d /etc/profile.d
 WORKDIR /usr/src/app

--- a/rails-8-dood/Dockerfile
+++ b/rails-8-dood/Dockerfile
@@ -6,6 +6,7 @@ RUN set -x \
     build-essential \
     libsqlite3-dev \
     libpq-dev \
+    libyaml-dev \
     tzdata \
     curl \
     git \
@@ -28,14 +29,14 @@ RUN set -x \
 RUN set -x \
   && groupadd -g 998 docker \
   && useradd -m -s /bin/bash -G docker -u 1000 rails
-ENV BUNDLE_PATH=/home/rails/.bundle
-ENV BUNDLE_APP_CONFIG=/home/rails/.bundle
-ENV BUNDLE_BIN=/home/rails/.bundle/bin
-ENV PATH=$BUNDLE_BIN:$PATH
 
 COPY ./profile.d /etc/profile.d
 WORKDIR /usr/src/app
 COPY ./README.md /usr/src/README.md
+ENV BUNDLE_PATH=/usr/src/app/.bundle
+ENV BUNDLE_APP_CONFIG=/usr/src/app/.bundle
+ENV BUNDLE_BIN=/usr/src/app/.bundle/bin
+ENV PATH=$BUNDLE_BIN:$PATH
 
 USER rails
 

--- a/rails-8-dood/Dockerfile
+++ b/rails-8-dood/Dockerfile
@@ -1,0 +1,25 @@
+FROM ruby:3.4-slim
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y \
+    build-essential \
+    libsqlite3-dev \
+    libpq-dev \
+    tzdata \
+    curl \
+    git \
+    vim \
+    jq \
+  && rm -rf /var/lib/apt/lists/* \
+  && gem install rails -v 8 \
+  && gem install pg \
+  && gem install --development rubocop \
+  && useradd -m -s /bin/bash -G sudo -u 1000 rails
+
+COPY ./profile.d /etc/profile.d
+WORKDIR /usr/src/app
+
+USER rails
+
+CMD ["/bin/bash", "-l"]

--- a/rails-8-dood/Dockerfile
+++ b/rails-8-dood/Dockerfile
@@ -31,4 +31,4 @@ COPY ./README.md /usr/src/README.md
 
 USER rails
 
-CMD ["/bin/bash", "-l"]
+CMD ["sleep", "infinity"]

--- a/rails-8-dood/Dockerfile
+++ b/rails-8-dood/Dockerfile
@@ -22,8 +22,11 @@ RUN set -x \
   && rm -rf /var/lib/apt/lists/* \
   && gem install rails -v 8 \
   && gem install pg \
-  && gem install --development rubocop \
-  && useradd -m -s /bin/bash -G sudo -u 1000 rails
+  && gem install --development rubocop
+
+RUN set -x \
+  && groupadd -g 998 docker \
+  && useradd -m -s /bin/bash -G docker -u 1000 rails
 
 COPY ./profile.d /etc/profile.d
 WORKDIR /usr/src/app

--- a/rails-8-dood/Dockerfile
+++ b/rails-8-dood/Dockerfile
@@ -19,6 +19,7 @@ RUN set -x \
 
 COPY ./profile.d /etc/profile.d
 WORKDIR /usr/src/app
+COPY ./README.md /usr/src/README.md
 
 USER rails
 

--- a/rails-8-dood/README.md
+++ b/rails-8-dood/README.md
@@ -1,0 +1,107 @@
+# Rails 8 開発環境
+
+このプロジェクトは、Dockerコンテナ上でRails 8の開発環境を提供しますわ。
+
+## 開発環境のセットアップ
+
+### 1. プロジェクトの初期化
+
+まず、新しいRailsプロジェクトを作成しますの。
+
+```bash
+rails new . --database=postgresql --css=tailwind
+```
+
+### 2. データベースの設定
+
+PostgreSQLのデータベースを作成しますわ。
+
+```bash
+rails db:create
+rails db:migrate
+```
+
+### 3. 開発サーバーの起動
+
+Railsの開発サーバーを起動しますの。
+
+```bash
+bin/dev
+```
+
+サーバーが起動したら、ブラウザで `http://localhost:3000` にアクセスして、アプリケーションが正しく動作しているか確認できますわ。
+
+## 便利なコマンド
+
+### ジェネレーターの使用
+
+新しいモデルやコントローラーを作成する際は、ジェネレーターを使用しますの。
+
+```bash
+# モデルの作成
+rails generate model User name:string email:string
+
+# コントローラーの作成
+rails generate controller Users index show
+```
+
+### データベースの操作
+
+```bash
+# マイグレーションの作成
+# カラムの追加（name: カラム名, string: データ型）
+rails generate migration AddNameToUsers name:string
+
+# インデックス付きカラムの追加（:index でインデックスを追加）
+rails generate migration AddEmailToUsers email:string:index
+
+# カラムの削除（Remove で始まるマイグレーション名）
+rails generate migration RemoveNameFromUsers name:string
+
+# 複数のカラムを一度に追加
+rails generate migration AddDetailsToUsers name:string email:string:index age:integer is_active:boolean
+
+# その他のデータ型の例
+rails generate migration AddPriceToProducts price:decimal
+rails generate migration AddPublishedAtToArticles published_at:datetime
+rails generate migration AddIsActiveToUsers is_active:boolean
+
+# マイグレーションの実行
+rails db:migrate
+
+# マイグレーションの取り消し
+rails db:rollback
+
+# データベースのリセット
+rails db:reset
+```
+
+### テストの実行
+
+```bash
+# 全テストの実行
+rspec
+
+# 特定のテストの実行
+rspec spec/models/user_spec.rb
+
+# 特定のテストケースの実行
+rspec spec/models/user_spec.rb:10
+```
+
+## 開発環境の特徴
+
+- Ruby 3.4
+- Rails 8
+- PostgreSQL
+- Tailwind CSS
+- Docker outside of Docker (DooD) 対応
+- Rubocopによるコードスタイルチェック
+- RSpecによるテスト
+
+## 注意事項
+
+- コンテナ内でDockerコマンドを使用する場合は、ホストのDockerソケットがマウントされていることを確認してください。
+- 開発中は`bin/dev`を使用して、Tailwind CSSのウォッチモードとRailsサーバーを同時に起動することをお勧めします。
+
+何かご質問がございましたら、お気軽にお申し付けくださいませ。

--- a/rails-8-dood/compose.yml
+++ b/rails-8-dood/compose.yml
@@ -6,3 +6,4 @@ services:
     volumes:
       - ./work:/usr/src/app # ローカルをコンテナ内にマウント
     command: sleep infinity
+    network_mode: host

--- a/rails-8-dood/compose.yml
+++ b/rails-8-dood/compose.yml
@@ -1,0 +1,8 @@
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./work:/usr/src/app # ローカルをコンテナ内にマウント
+    command: sleep infinity

--- a/rails-8-dood/profile.d/alias.sh
+++ b/rails-8-dood/profile.d/alias.sh
@@ -1,0 +1,1 @@
+alias ll='ls -la'


### PR DESCRIPTION
Fixes #30 

Rails8がプリインストールされ、かつ、[DooD](https://zenn.dev/js4000all/scraps/f5524a9af752a2)が利用可能なDevコンテナを追加しました。

---

なお、技術スタックの一貫性の観点では、`develop-rails-6-app-with-containers`のように、そもそも開発環境と同時にDBサーバも起動するという構成も有効であろうと思われます。

- Dev Container側：チームやプロジェクト横断で技術スタックを固定したい場合に有効
- プロジェクト側(DooD/DinD)：チームやプロジェクトに技術スタック選択の裁量を与えたい場合に有効
