### PR TITLE
amplifyを使うReact用devcontainerの追加

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "shared-devcon-rust"]
 	path = shared-devcon-rust
 	url = https://github.com/weworku/shared-devcon-rust.git
+[submodule "shared-devcon-react-amplify"]
+	path = shared-devcon-react-amplify
+	url = https://github.com/weworku/shared-devcon-react-amplify.git


### PR DESCRIPTION
# 概要

Reactのdevcontainerとは別に、amplifyと組み合わせたいとき用のコンテナを作成

そのリポジトリ自体は、以下に作成
https://github.com/weworku/shared-devcon-react-amplify

本PRでは、管理元の[shared-devcontainer](https://github.com/weworku/shared-devcontainer)にsubmoduleとして追加するPR
([shared-devcontainer](https://github.com/weworku/shared-devcontainer)はdevcontainerを管理しやすいようにするリポジトリになると嬉しい)

# 確認観点

この辺りが確認出来ていると良さそう

- [x] .gitmodules のURLやpathが正しいか
- [x] サブモジュールのディレクトリがあるか
- [x] devcontainer が VS Code 上で正常に開くか
- [x] amplify -v が動作するか